### PR TITLE
Add more detailed errors when failing to parse cluster definitions

### DIFF
--- a/common/src/main/java/dev/ybrig/ck8s/cli/common/Ck8sUtils.java
+++ b/common/src/main/java/dev/ybrig/ck8s/cli/common/Ck8sUtils.java
@@ -81,9 +81,10 @@ public class Ck8sUtils
         return streamClusterYaml(ck8sPath)
                 .filter(p -> {
                     try {
-                        return filter.test(new ClusterConfiguration(Mapper.yamlMapper().readMap(p)));
+                        Map<String, Object> m = Mapper.yamlMapper().readMap(p);
+                        return filter.test(new ClusterConfiguration(m));
                     } catch (Exception e) {
-                        throw new RuntimeException("Error parsing cluster definition file " + p);
+                        throw new RuntimeException("Error parsing cluster definition file " + p + ": " + e.getMessage());
                     }
                 })
                 .findFirst()


### PR DESCRIPTION
Just some minor stuff.